### PR TITLE
Please support scientific notation

### DIFF
--- a/reverse.js
+++ b/reverse.js
@@ -22,12 +22,12 @@
   function normalizePath(d) {
     // preprocess "d" so that we have spaces between values
     d = d.replace(/,/g,' ')
-         .replace(/-/g,' -')
+         .replace(/([^eE])-/g,'$1 -')
          .replace(/\s*([achlmqstvzACHLMQSTVZ])\s*/g," $1 ")
          .replace(/\s+/g, ' ');
 
     // set up the variables used in this function
-    var instructions = d.replace(/([a-zA-Z])\s?/g,"|$1").split("|"),
+    var instructions = d.replace(/([achlmqstvzACHLMQSTVZ])\s?/g,"|$1").split("|"),
         instructionLength = instructions.length,
         i,
         instruction,

--- a/test.js
+++ b/test.js
@@ -49,11 +49,13 @@ normalized = normalize(path);
 if (normalized !== prenormalized) fail(`partially collapsed flag arc (normalize): ${normalized}`);
 if (prenormalized !== reverse(reverse(path))) fail("partially collapsed flag arc (round trip)");
 
+
 path = "m 1e1 0 l 0 10";
 prenormalized = "M 10 0 L 10 10";
 normalized = normalize(path);
 if (normalized !== prenormalized) fail(`scientific notation, lowercase, positive exponent(normalize): ${normalized}`);
 if (prenormalized !== reverse(reverse(path))) fail("scientific notation, lowercase, positive exponent (round trip)");
+
 
 path = "m 1E-1 0 l 10 10";
 prenormalized = "M 0.1 0 L 10.1 10";

--- a/test.js
+++ b/test.js
@@ -48,3 +48,15 @@ prenormalized = "M 0 0 A 5.5 5.5 0 0 1 100 -11 Z";
 normalized = normalize(path);
 if (normalized !== prenormalized) fail(`partially collapsed flag arc (normalize): ${normalized}`);
 if (prenormalized !== reverse(reverse(path))) fail("partially collapsed flag arc (round trip)");
+
+path = "m 1e1 0 l 0 10";
+prenormalized = "M 10 0 L 10 10";
+normalized = normalize(path);
+if (normalized !== prenormalized) fail(`scientific notation, lowercase, positive exponent(normalize): ${normalized}`);
+if (prenormalized !== reverse(reverse(path))) fail("scientific notation, lowercase, positive exponent (round trip)");
+
+path = "m 1E-1 0 l 10 10";
+prenormalized = "M 0.1 0 L 10.1 10";
+normalized = normalize(path);
+if (normalized !== prenormalized) fail(`scientific notation, uppercase, negative exponent (normalize): ${normalized}`);
+if (prenormalized !== reverse(reverse(path))) fail("scientific notation, uppercase, negative exponent (round trip)");


### PR DESCRIPTION
Hey, thanks for this library, it's been very useful.

I just ran into the same issue described here: https://github.com/Pomax/svg-path-reverse/issues/6, prepared the PR before I found the closed issue and discussion. I changed the patch to the suggestion there, as it was even better than mine.

The specs cited by @euglv explicitly allow numbers with scientific notation in paths. I'll link them in again, because I think it is relevant: https://www.w3.org/1999/08/WD-SVG-19990812/paths.html#PathDataBNF, so I think it would be safest to support them, if the library wants to handle general SVG paths.

Are there any dangers in supporting it? Can the support *break* other uses? You mentioned CnC, but it seems to me that there is no conflict, if the scientific notation is not used to begin with.

Proposed workarounds:
An SVG optimizer might be a solution in some cases, but for performance reasons I don't think it is feasible to SVG optimize every path before using it with svg-path-reverse. I also don't think it's feasible to wrap all path generating calculations into additional sanitizing code to strip them of scientific notation, especially if you don't expect this to be a problem, if they come from other libraries, then they'd have to be parsed again.

Please reconsider supporting this as it makes svg-path-reverse much safer for its users. These errors likely only show up with edge cases in prod and then fail very unintuitively. I used the library without problems for about 2 months, until some situations required rotations.

If you really, really don't want to support this, then please add a check and an error message that explains the situation and fails hard, so it is immediately obvious what happened.